### PR TITLE
Add setuptools and setuptools-scm to host requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@ requirements:
     - python {{ python_min }}
     - pip
     - pytest-runner
+    - setuptools >=61
+    - setuptools-scm >=8
   run:
     - python >={{ python_min }}
     - scipy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: fe8772abdcc18763034ec4e9a8bc5e81c85e05680acb4653f9ebbd13a07607cf
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 


### PR DESCRIPTION
Setuptools and setuptools-scm are listed in pyproject.toml but are missing from the conda recipe. This causes the built package to have version 0.0.0.

The issue is described in more detail in conda-forge/earthkit-data-feedstock#81. I've created a pull request on that repository as conda-forge/earthkit-data-feedstock#82.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.